### PR TITLE
fix: prevent infinite recursion in squarified treemap layout

### DIFF
--- a/src/renderer/components/Topology/topology-utils.ts
+++ b/src/renderer/components/Topology/topology-utils.ts
@@ -250,6 +250,7 @@ interface Weighted<T> {
 
 export function squarify<T>(items: Weighted<T>[], area: Rect): SquarifiedItem<T>[] {
   const out: SquarifiedItem<T>[] = [];
+  if (!(area.w > 0) || !(area.h > 0)) return out;
   const sorted = items
     .filter((i) => i.value > 0)
     .slice()
@@ -267,6 +268,8 @@ export function squarify<T>(items: Weighted<T>[], area: Rect): SquarifiedItem<T>
 
 function layoutRow<T>(items: Weighted<T>[], rect: Rect, out: SquarifiedItem<T>[]) {
   if (items.length === 0) return;
+  // Catch zero, negative, and NaN dimensions (can arise after repeated shrinking)
+  if (!(rect.w > 0) || !(rect.h > 0)) return;
   const shortSide = Math.min(rect.w, rect.h);
   const row: Weighted<T>[] = [];
   let bestRatio = Infinity;
@@ -274,14 +277,18 @@ function layoutRow<T>(items: Weighted<T>[], rect: Rect, out: SquarifiedItem<T>[]
   for (const it of items) {
     const candidate = [...row, it];
     const ratio = worstRatio(candidate, shortSide);
-    if (ratio <= bestRatio) {
+    // Always accept the first item — NaN from a degenerate rect must not leave row empty,
+    // which would cause items.slice(0) to recurse on the same list indefinitely.
+    if (row.length === 0 || ratio <= bestRatio) {
       row.push(it);
       bestRatio = ratio;
     } else {
       // Emit current row, recurse on the rest with the remaining rect
       const rowArea = row.reduce((s, r) => s + r.value, 0);
       placeRow(row, rect, out);
-      const newRect = shrinkRect(rect, rowArea / shortSide);
+      const consumed = rowArea / shortSide;
+      if (!(consumed > 0)) return;
+      const newRect = shrinkRect(rect, consumed);
       layoutRow(items.slice(row.length), newRect, out);
       return;
     }


### PR DESCRIPTION
## Problem

Opening the Topology pods view can crash with:
RangeError: Maximum call stack size exceeded

The issue is in layoutRow (topology-utils.ts). When the container has zero (or near-zero) dimensions during the initial render, worstRatio returns NaN. Since `NaN` <= `Infinity` evaluates to false in JavaScript, execution immediately enters the else branch while row is still empty.

As a result, items.slice(0) returns the entire unchanged list, and layoutRow is called again with the same inputs, causing infinite recursion until the stack overflows.

## Fix

Three guards added to `squarify` / `layoutRow`:

1. **`squarify`** — bail early when `area.w` or `area.h` is non-positive (catches NaN too via `!(x > 0)`).
2. **`layoutRow` entry** — bail early when rect dimensions are zero, negative, or NaN (can arise after repeated shrinking).
3. **`layoutRow` loop** — always accept the first item unconditionally, so `row` is never empty when the `else` branch fires.

## Stack trace (before fix)

```
RangeError: Maximum call stack size exceeded
    at topology-utils.js:172:26   ← worstRatio reduce
    at layoutRow (topology-utils.js:156:19)
    at layoutRow (topology-utils.js:164:7)
    at layoutRow (topology-utils.js:164:7)
    ...
```
<img width="1045" height="809" alt="image" src="https://github.com/user-attachments/assets/49142f28-17f2-4b67-ad1e-80c03e084502" />
